### PR TITLE
Favorite Fuctionality

### DIFF
--- a/src/components/SelfFeedbackBar.js
+++ b/src/components/SelfFeedbackBar.js
@@ -1,3 +1,5 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import {
     Box,
     Flex,
@@ -10,15 +12,20 @@ import {
     MenuDivider,
     useColorModeValue,
 } from '@chakra-ui/react';
-import { deleteWorkoutFromCollecton } from '../context/StoreContext';
-import { useNavigate } from 'react-router-dom';
+import { 
+    deleteWorkoutFromCollecton,
+    addFavoriteWorkoutToUserDocument,
+    removeFavoriteWorkoutFromUserDocument,
+    updateFavoriteWorkout 
+} from '../context/StoreContext';
 import { UserAuth } from '../context/AuthContext';
-
-export default function SelfFeedbackBar({ workoutName, isPrivate, wasDeleted, setWasDeleted }) {
+export default function SelfFeedbackBar({ workoutName, workoutId, isPrivate, isFavorite, wasDeleted, setWasDeleted }) {
     // Navigate Hook, used to rerouting user
     const navigate = useNavigate();
     // Firebase user object
     const { user } = UserAuth();
+    // State
+    const [isFavorited, setIsFavorited] = useState(isFavorite);
 
     // Handles deletion of workout
     async function handleDeleteWorkout() {
@@ -32,6 +39,24 @@ export default function SelfFeedbackBar({ workoutName, isPrivate, wasDeleted, se
             console.log("Unable to delete workout: " + error);
         }
     }
+    
+
+    async function handleFavoriteWorkout() {
+        try {
+            setIsFavorited(!isFavorited);
+            if (!isFavorited) {
+                console.log("Workout is favorited")
+                await addFavoriteWorkoutToUserDocument(user, workoutId);
+            } else {
+                console.log("Workout unfavorited")
+                await removeFavoriteWorkoutFromUserDocument(user, workoutId);
+            }
+            await updateFavoriteWorkout(user, workoutName, workoutId, isPrivate, !(isFavorited));
+        } catch (error) {
+            console.log("Unable to favorite workout: " + error);
+        }
+    }
+
 
     return (
         <>
@@ -60,7 +85,7 @@ export default function SelfFeedbackBar({ workoutName, isPrivate, wasDeleted, se
                             </Menu>
                         </Flex>
 
-                        <Button bg="green" color="white">
+                        <Button bg="green" color="white" onClick={handleFavoriteWorkout}>
                             Favorite
                         </Button>
                     </HStack>

--- a/src/components/WorkoutCards.js
+++ b/src/components/WorkoutCards.js
@@ -15,7 +15,6 @@ import { Link } from 'react-router-dom';
 import { HamburgerIcon, ExternalLinkIcon, DeleteIcon, StarIcon } from '@chakra-ui/icons';
 import { useState } from 'react';
 import { deleteWorkoutFromCollecton } from '../context/StoreContext';
-import { useNavigate } from 'react-router-dom';
 import { updateFavoriteWorkout, addFavoriteWorkoutToUserDocument, removeFavoriteWorkoutFromUserDocument } from '../context/StoreContext';
 
 var colors = ['red', 'green', 'blue', 'yellow', 'orange', 'pink'];
@@ -49,15 +48,10 @@ export default function WorkoutCard({ user, workoutName, creator, isPrivate, wor
     // Convert Date to String
     const date = createdAt.toDate().toDateString();
     // Delete Workout
-    const navigate = useNavigate();
     async function handleDeleteWorkout() {
         try {
             await deleteWorkoutFromCollecton(user, workoutName, isPrivate);
             setWasDeleted(true);
-            setTimeout(() => {
-                //navigate('/dashboard');
-                window.location.reload();
-            }, 100);
         } catch (error) {
             console.log("Unable to delete workout: " + error);
         }
@@ -87,9 +81,9 @@ export default function WorkoutCard({ user, workoutName, creator, isPrivate, wor
             <Box py={"4px"} >
                 <HStack justifyContent="center">
                     {isFavorited ?
-                        <StarIcon w={8} h={8} color="yellow.400" onClick={handleFavoriteWorkout}/>
+                        <StarIcon w={4} h={8} color="yellow.400" onClick={handleFavoriteWorkout} />
                         :
-                        <StarIcon w={8} h={8} color="gray.600" onClick={handleFavoriteWorkout}/>
+                        <StarIcon w={4} h={8} color="gray.900" onClick={handleFavoriteWorkout} />
                     }
                     <Text fontWeight="500" fontSize="xl" >
                         {workoutName}

--- a/src/components/WorkoutCards.js
+++ b/src/components/WorkoutCards.js
@@ -12,7 +12,7 @@ import {
     IconButton
 } from '@chakra-ui/react';
 import { Link } from 'react-router-dom';
-import { HamburgerIcon, ExternalLinkIcon, DeleteIcon } from '@chakra-ui/icons';
+import { HamburgerIcon, ExternalLinkIcon, DeleteIcon, StarIcon } from '@chakra-ui/icons';
 import { useState } from 'react';
 import { deleteWorkoutFromCollecton } from '../context/StoreContext';
 
@@ -40,12 +40,12 @@ function WorkoutWrapper({ children, wasDeleted }) {
     }
 }
 
-export default function WorkoutCard({ user, workoutName, creator, isPrivate, workoutId, createdAt }) {
+export default function WorkoutCard({ user, workoutName, creator, isPrivate, workoutId, createdAt, isFavorite }) {
     // React State
     const [wasDeleted, setWasDeleted] = useState(false);
+    const [isFavorited, setIsFavorited] = useState(isFavorite);
     // Convert Date to String
     const date = createdAt.toDate().toDateString();
-
     // Delete Workout
     async function handleDeleteWorkout() {
         try {
@@ -62,7 +62,6 @@ export default function WorkoutCard({ user, workoutName, creator, isPrivate, wor
     return (
         <WorkoutWrapper wasDeleted={wasDeleted}>
             <Box py={"4px"} >
-
                 <Text fontWeight="500" fontSize="xl" >
                     {workoutName}
                 </Text>
@@ -90,6 +89,11 @@ export default function WorkoutCard({ user, workoutName, creator, isPrivate, wor
                         </MenuItem>
                     </MenuList>
                 </Menu>
+                { isFavorited ?
+                <StarIcon w={8} h={8} color="yellow.400" />
+                :
+                <StarIcon w={8} h={8} color="gray.600" />
+            }
             </Box>
 
             {/* Portion for labels */}

--- a/src/components/WorkoutCards.js
+++ b/src/components/WorkoutCards.js
@@ -16,7 +16,7 @@ import { HamburgerIcon, ExternalLinkIcon, DeleteIcon, StarIcon } from '@chakra-u
 import { useState } from 'react';
 import { deleteWorkoutFromCollecton } from '../context/StoreContext';
 import { useNavigate } from 'react-router-dom';
-import { updateFavoriteWorkout, addFavoriteWorkoutToUserDocument } from '../context/StoreContext';
+import { updateFavoriteWorkout, addFavoriteWorkoutToUserDocument, removeFavoriteWorkoutFromUserDocument } from '../context/StoreContext';
 
 var colors = ['red', 'green', 'blue', 'yellow', 'orange', 'pink'];
 var textColors = ['black', 'white', 'white', 'black', 'black', 'black'];
@@ -66,8 +66,14 @@ export default function WorkoutCard({ user, workoutName, creator, isPrivate, wor
     async function handleFavoriteWorkout() {
         try {
             setIsFavorited(!isFavorited);
-            await updateFavoriteWorkout(user, workoutName, isPrivate, !(isFavorited));
-            await addFavoriteWorkoutToUserDocument(user, workoutId);
+            if (!isFavorited) {
+                console.log("Workout is favorited")
+                await addFavoriteWorkoutToUserDocument(user, workoutId);
+            } else {
+                console.log("Workout unfavorited")
+                await removeFavoriteWorkoutFromUserDocument(user, workoutId);
+            }
+            await updateFavoriteWorkout(user, workoutName, workoutId, isPrivate, !(isFavorited));
         } catch (error) {
             console.log("Unable to favorite workout: " + error);
         }

--- a/src/context/AuthContext.js
+++ b/src/context/AuthContext.js
@@ -40,6 +40,7 @@ export const AuthProvider = ({ children }) => {
     return user.uid;
   }
 
+
   useEffect(() => {
     const unsubscribe = onAuthStateChanged(auth, (currentUser) => {
       setUser(currentUser);

--- a/src/context/StoreContext.js
+++ b/src/context/StoreContext.js
@@ -1,14 +1,26 @@
 import { database } from '../firebase';
-import { doc, getDoc, setDoc, deleteDoc, Timestamp, updateDoc, arrayUnion, collection, getDocs } from 'firebase/firestore';
+import {
+    doc,
+    getDoc,
+    setDoc,
+    deleteDoc,
+    Timestamp,
+    updateDoc,
+    arrayUnion,
+    arrayRemove,
+    collection,
+    getDocs,
+    query,
+    where
+} from 'firebase/firestore';
 
 export function addUserToCollection(uid, username, email) {
     return setDoc(doc(database, "users", uid), {
         username: username,
         email: email,
+        favoritedWorkouts: [],
     });
 };
-
-
 
 export async function addWorkoutToDocument(user, data, isPrivate) {
     let subcollectionName = isPrivate ? "Private Workouts" : "Public Workouts";
@@ -80,12 +92,17 @@ export async function deleteWorkoutFromCollecton(user, workoutName, isPrivate) {
 }
 
 
-export async function updateFavoriteWorkout(user, workoutName, isPrivate, favoriteValue) {
+export async function updateFavoriteWorkout(user, workoutName, workoutId, isPrivate, favoriteValue) {
     let subcollectionName = isPrivate ? "Private Workouts" : "Public Workouts";
     const ref = doc(database, "users", user.uid, subcollectionName, workoutName);
+    const mainRef = doc(database, "workouts", workoutId);
     try {
-        console.log("Updating favorite: ", favoriteValue);
+        // Update favorite in user's collection
         await updateDoc(ref, {
+            favorite: favoriteValue,
+        });
+        // Update favorite in main collection
+        await updateDoc(mainRef, {
             favorite: favoriteValue,
         });
         return true;
@@ -108,15 +125,39 @@ export async function addFavoriteWorkoutToUserDocument(user, workoutId) {
     }
 }
 
+export async function removeFavoriteWorkoutFromUserDocument(user, workoutId) {
+    const ref = doc(database, "users", user.uid);
+    try {
+        await updateDoc(ref, {
+            favoritedWorkouts: arrayRemove(workoutId),
+        });
+        return true;
+    } catch (error) {
+        console.error("Error removing favorite: ", error);
+        return false;
+    }
+}
+
+// Get all workouts from user's collection
 export async function getUserFavoritedWorkouts(user) {
-    const workoutsRef = collection(database, 'workouts')
-    const favoritedWorkouts = user.favorites || []
-    const workoutDocs = await getDocs(workoutsRef)
-    const workouts = workoutDocs.docs.map((doc) => {
-      const workout = doc.data()
-      return { ...workout, id: doc.id }
-    })
-    const favoritedWorkoutData = workouts.filter((workout) => favoritedWorkouts.includes(workout.id))
-    return favoritedWorkoutData
-  }
-  
+    const ref = doc(database, "users", user.uid);
+    const docSnap = await getDoc(ref);
+    if (docSnap.exists()) {
+        return docSnap.data().favoritedWorkouts;
+    }
+}
+
+// Get all workouts from workouts collection
+export async function getFavoritedWorkoutsFromCollection(user) {
+    try {
+        const favoritedWorkouts = await getUserFavoritedWorkouts(user);
+        const workoutsRef = collection(database, 'workouts');
+        const workoutsQuery = query(workoutsRef, where('workoutId', 'in', favoritedWorkouts));
+        const querySnapshot = await getDocs(workoutsQuery);
+        const workoutList = querySnapshot.docs.map((doc) => doc.data());
+        return workoutList;
+    } catch (error) {
+        console.error('Error in getFavoritedWorkoutsFromCollection: ', error);
+        throw error;
+    }
+}

--- a/src/pages/Dashboard.js
+++ b/src/pages/Dashboard.js
@@ -67,11 +67,11 @@ export default function Dashboard() {
                     isPrivate={workout.isPrivate}
                     workoutId={workout.workoutId}
                     createdAt={workout.createdAt}
+                    isFavorite={workout.favorite}
                 />
             </div>
         )
     });
-
 
     const userWorkoutCards = userWorkouts.map((workout) => {
         return (
@@ -84,6 +84,7 @@ export default function Dashboard() {
                     isPrivate={workout.isPrivate}
                     workoutId={workout.workoutId}
                     createdAt={workout.createdAt}
+                    isFavorite={workout.favorite}
                 />
             </div>
         )

--- a/src/pages/Favoriteworkouts.js
+++ b/src/pages/Favoriteworkouts.js
@@ -1,17 +1,86 @@
 import Navbar from "../components/Navbar";
 import Searchbar from "../components/Searchbar";
 import Background from "../components/Background";
-import WorkoutCards from "../components/WorkoutCards";
 import FavoritesDropdown from "../components/FavoritesDropdown";
-import { HStack, Heading} from '@chakra-ui/react'
-
+import { HStack, Heading, Box, Stack } from '@chakra-ui/react'
+import { UserAuth } from "../context/AuthContext";
+import { useEffect, useState } from "react";
+import { getUsername } from "../context/StoreContext";
+import WorkoutCard from "../components/WorkoutCards";
+import { collection, getDocs, orderBy, query } from "firebase/firestore";
+import { database } from "../firebase";
 export default function Favoriteworkouts() {
+    // Auth
+    const { user, getUserId } = UserAuth();
+    // State
+    const [privateWorkouts, setPrivateWorkouts] = useState([]);
+    const [publicWorkouts, setPublicWorkouts] = useState([]);
+    const [userWorkouts, setUserWorkouts] = useState([]);
+    const [userName, setUserName] = useState("");
+    const [favoriteWorkouts, setFavoriteWorkouts] = useState([]);
+
+    useEffect(() => {
+        async function fetchData() {
+            const uid = getUserId();
+            const privateQ = query(
+                collection(database, "users", uid, "Private Workouts"), orderBy("createdAt", "desc")
+            );
+            const publicQ = query(
+                collection(database, "users", uid, "Public Workouts"), orderBy("createdAt", "desc")
+            );
+            const privateSnapshot = getDocs(privateQ);
+            const publicSnapshot = getDocs(publicQ);
+            const [privateData, publicData] = await Promise.all([
+                privateSnapshot.then((querySnapshot) => {
+                    return querySnapshot.docs.map((doc) => doc.data());
+                }),
+                publicSnapshot.then((querySnapshot) => {
+                    return querySnapshot.docs.map((doc) => doc.data());
+                }),
+            ]);
+            setPrivateWorkouts(privateData);
+            setPublicWorkouts(publicData);
+            const name = await getUsername(user);
+            setUserName(name);
+        }
+        fetchData();
+    }, [user]);
+
+    useEffect(() => {
+        const workouts = [...privateWorkouts, ...publicWorkouts];
+        const uniqueWorkouts = workouts.filter((workout, index) => {
+            const exists = workouts.findIndex((w) => w.workoutName === workout.workoutName);
+            return exists === index;
+        });
+        setUserWorkouts(uniqueWorkouts);
+    }, [privateWorkouts, publicWorkouts]);
+
+    useEffect(() => {
+        const favoriteWorkouts = userWorkouts.filter(workout => workout.favorite);
+        setFavoriteWorkouts(favoriteWorkouts);
+    }, [userWorkouts]);
+
+    const favoriteWorkoutCards = favoriteWorkouts.map((workout) => {
+        return (
+            <div key={workout.workoutName}>
+                <WorkoutCard
+                    key={workout.workoutName}
+                    workoutName={workout.workoutName}
+                    creator={userName}
+                    isPrivate={workout.isPrivate}
+                    workoutId={workout.workoutId}
+                    createdAt={workout.createdAt}
+                />
+            </div>
+        );
+    });
+
     return (
         <div>
             <Background />
             <Navbar />
             <HStack >
-                <Searchbar /> 
+                <Searchbar />
                 <FavoritesDropdown />
             </HStack>
             <div id="favoritecontentdiv">
@@ -20,12 +89,26 @@ export default function Favoriteworkouts() {
                 </style>
 
                 <HStack>
-                    <Heading marginTop='2%' marginLeft='5%' as='h3' size='lg' float='left'  color='white'>
-                            Favorite Workouts
+                    <Heading marginTop='2%' marginLeft='5%' as='h3' size='lg' float='left' color='white'>
+                        Favorite Workouts
                     </Heading>
                 </HStack>
-
-                <WorkoutCards />
+                <Box sx={{ display: "flex", alignItems: "center", margin: "auto" }}>
+                    <Stack
+                        direction={{ base: 'column', md: 'row' }}
+                        textAlign="center"
+                        justify="center"
+                        marginLeft="30px"
+                        marginRight="30px"
+                        py={12}
+                        style={{
+                            display: 'grid',
+                            gridTemplateColumns: 'repeat(4, minmax(200px, 350px))',
+                            gridGap: '30px',
+                        }} >
+                        {favoriteWorkoutCards}
+                    </Stack>
+                </Box>
             </div>
         </div>
     )

--- a/src/pages/Myworkouts.js
+++ b/src/pages/Myworkouts.js
@@ -66,6 +66,7 @@ export default function Myworkouts() {
                     isPrivate={workout.isPrivate}
                     workoutId={workout.workoutId}
                     createdAt={workout.createdAt}
+                    isFavorite={workout.favorite}
                 />
             </div>
         );

--- a/src/pages/WorkoutView.js
+++ b/src/pages/WorkoutView.js
@@ -78,11 +78,17 @@ export default function WorkoutView() {
                     Workout has been deleted! Redirecting...
                 </Alert>
             }
-            {ownsWorkout ? <SelfFeedbackBar workoutName={workout.workoutName} isPrivate={workout.isPrivate} wasDeleted={wasDeleted} setWasDeleted={setWasDeleted} /> : <FeedbackBar />}
-            <div  id="viewdiv"> 
-                    <style>
-                        {'#viewdiv { background-color:rgba(20,20,20,0.6); margin-top:1%; display:inline-block; width:90%; height:auto; min-height:100% }'}
-                    </style>
+            {
+                ownsWorkout
+                    ?
+                    <SelfFeedbackBar workoutName={workout.workoutName} workoutId={workout.workoutId} isPrivate={workout.isPrivate} isFavorite={workout.favorite} wasDeleted={wasDeleted} setWasDeleted={setWasDeleted} />
+                    :
+                    <FeedbackBar
+                    />}
+            <div id="viewdiv">
+                <style>
+                    {'#viewdiv { background-color:rgba(20,20,20,0.6); margin-top:1%; display:inline-block; width:90%; height:auto; min-height:100% }'}
+                </style>
                 <div id="workoutviewcontentdiv">
                     <style>
                         {'#workoutviewcontentdiv { background-color:white; margin-top:1%; display:inline-block; width:90%; padding-bottom:1%"; margin-bottom:"1%";}'}
@@ -93,7 +99,7 @@ export default function WorkoutView() {
                         createdAt={workout.createdAt}
                         isPrivate={workout.isPrivate}
                     />
-                    <WorkoutViewTable exercises={workout.workoutExercises} onExerciseChange={handleExerciseChange}/>
+                    <WorkoutViewTable exercises={workout.workoutExercises} onExerciseChange={handleExerciseChange} />
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Description

This PR implements the favorite functionality. Meaning users can now favorite workouts. This was accomplished by adding a `favorite: boolean` field in the `user/workout` document on firestore and dealing with fetching logic.

### Features/changes:
- Added query to fetch favorited workout cards
- Users can click on the favorite icon to favorite a workout of their choosing
- Users can favorite a work in the workout viewer
- `/myfavorites` route now works
- Optimized dashboard fetching logic, Public and Private workout queries now have realtime listeners (specifically `onSnapshot`)

